### PR TITLE
Feature/3773: Create MDM Endpoints for Gas Level Code (Linearity Summary)

### DIFF
--- a/src/acquisition-method-code/acquisition-method-code.service.spec.ts
+++ b/src/acquisition-method-code/acquisition-method-code.service.spec.ts
@@ -4,7 +4,7 @@ import { AcquisitionMethodCodeService } from './acquisition-method-code.service'
 import { AcquisitionMethodCodeRepository } from './acquisition-method-code.repository';
 import { AcquisitionMethodCodeMap } from '../maps/acquistion-method-code.map';
 import { HttpModule } from '@nestjs/axios';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { LoggerModule } from '@us-epa-camd/easey-common/logger';
 
 describe('AcquisitionMethodCodeService', () => {
@@ -38,6 +38,7 @@ describe('AcquisitionMethodCodeService', () => {
   });
 
   it('should be defined', () => {
+    expect(repository).toBeDefined();
     expect(service).toBeDefined();
   });
 });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,6 +53,7 @@ import { RelationshipsModule } from './relationships/relationships.module';
 import { TestReasonCodeModule } from './test-reason-code/test-reason-code.module';
 import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { ReportingPeriodModule } from './reporting-period/reporting-period.module';
+import { GasTypeCodeModule } from './gas-type-code/gas-type-code.module';
 
 @Module({
   imports: [
@@ -109,6 +110,7 @@ import { ReportingPeriodModule } from './reporting-period/reporting-period.modul
     TestReasonCodeModule,
     TestTypeCodeModule,
     ReportingPeriodModule,
+    GasTypeCodeModule,
   ],
 })
 export class AppModule {}

--- a/src/dto/gas-type-code.dto.ts
+++ b/src/dto/gas-type-code.dto.ts
@@ -1,0 +1,4 @@
+export class GasTypeCodeDTO {
+  gasTypeCode: string;
+  gasTypeCodeDescription: string;
+}

--- a/src/entities/gas-type-code.entity.ts
+++ b/src/entities/gas-type-code.entity.ts
@@ -1,0 +1,20 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'camdecmpsmd.gas_type_code' })
+export class GasTypeCode extends BaseEntity {
+  @PrimaryColumn({
+    type: 'varchar',
+    length: 7,
+    nullable: false,
+    name: 'gas_type_cd',
+  })
+  gasTypeCode: string;
+
+  @Column({
+    type: 'varchar',
+    length: 1000,
+    nullable: false,
+    name: 'gas_type_description',
+  })
+  gasTypeDescription: string;
+}

--- a/src/gas-type-code/gas-type-code.controller.spec.ts
+++ b/src/gas-type-code/gas-type-code.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GasTypeCodeDTO } from '../dto/gas-type-code.dto';
+import { GasTypeCodeController } from './gas-type-code.controller';
+import { GasTypeCodeService } from './gas-type-code.service';
+
+const gasTypeCodeDTO = new GasTypeCodeDTO();
+
+const mockService = () => ({
+  getGasTypeCodes: jest.fn().mockResolvedValue([gasTypeCodeDTO]),
+});
+
+describe('GasTypeCodeController', () => {
+  let controller: GasTypeCodeController;
+  let service: GasTypeCodeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GasTypeCodeController],
+      providers: [
+        {
+          provide: GasTypeCodeService,
+          useFactory: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<GasTypeCodeController>(GasTypeCodeController);
+    service = module.get<GasTypeCodeService>(GasTypeCodeService);
+  });
+
+  describe('getQualTypeCodes', () => {
+    it('should call the QualTypeCodeService and return a list of qual data type codes', async () => {
+      const result = await controller.getGasTypeCodes();
+      expect(result).toEqual([gasTypeCodeDTO]);
+      expect(service.getGasTypeCodes).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gas-type-code/gas-type-code.controller.ts
+++ b/src/gas-type-code/gas-type-code.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GasTypeCodeDTO } from '../dto/gas-type-code.dto';
+import { GasTypeCodeService } from './gas-type-code.service';
+
+@Controller()
+@ApiSecurity('APIKey')
+@ApiTags('Gas Type Codes')
+export class GasTypeCodeController {
+  constructor(private readonly service: GasTypeCodeService) {}
+
+  @Get()
+  @ApiOkResponse({
+    isArray: true,
+    type: GasTypeCodeDTO,
+    description: 'Retrieves all gas type codes.',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid Request',
+  })
+  getGasTypeCodes(): Promise<GasTypeCodeDTO[]> {
+    return this.service.getGasTypeCodes();
+  }
+}

--- a/src/gas-type-code/gas-type-code.module.ts
+++ b/src/gas-type-code/gas-type-code.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { GasTypeCodeService } from './gas-type-code.service';
+import { GasTypeCodeController } from './gas-type-code.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { GasTypeCodeRepository } from './gas-type-code.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GasTypeCodeRepository])],
+  controllers: [GasTypeCodeController],
+  providers: [GasTypeCodeService],
+})
+export class GasTypeCodeModule {}

--- a/src/gas-type-code/gas-type-code.repository.spec.ts
+++ b/src/gas-type-code/gas-type-code.repository.spec.ts
@@ -1,0 +1,45 @@
+import { Test } from '@nestjs/testing';
+import { GasTypeCodeDTO } from '../dto/gas-type-code.dto';
+import { SelectQueryBuilder } from 'typeorm';
+import { GasTypeCodeRepository } from './gas-type-code.repository';
+import { GasTypeCode } from 'src/entities/gas-type-code.entity';
+
+const mockQueryBuilder = () => ({
+  select: jest.fn(),
+  getMany: jest.fn(),
+});
+
+describe('GasTypeCodeRepository', () => {
+  let repository;
+  let queryBuilder;
+  const gasTypeCodeDTO = new GasTypeCodeDTO();
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        GasTypeCodeRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    repository = module.get<GasTypeCodeRepository>(GasTypeCodeRepository);
+
+    queryBuilder = module.get<SelectQueryBuilder<GasTypeCode>>(
+      SelectQueryBuilder,
+    );
+
+    repository.createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
+  });
+
+  describe('getGasTypeCodes', () => {
+    it('calls createQueryBuilder and gets all gas type codes from the repository', async () => {
+      queryBuilder.select.mockReturnValue(queryBuilder);
+      queryBuilder.getMany.mockReturnValue(gasTypeCodeDTO);
+
+      let result = await repository.getGasTypeCodes();
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual(gasTypeCodeDTO);
+    });
+  });
+});

--- a/src/gas-type-code/gas-type-code.repository.ts
+++ b/src/gas-type-code/gas-type-code.repository.ts
@@ -1,0 +1,14 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { GasTypeCode } from '../entities/gas-type-code.entity';
+
+@EntityRepository(GasTypeCode)
+export class GasTypeCodeRepository extends Repository<GasTypeCode> {
+  async getGasTypeCodes(): Promise<GasTypeCode[]> {
+    const query = this.createQueryBuilder('gtc').select([
+      'gtc.gasTypeCode',
+      'gtc.gasTypeDescription',
+    ]);
+
+    return query.getMany();
+  }
+}

--- a/src/gas-type-code/gas-type-code.service.spec.ts
+++ b/src/gas-type-code/gas-type-code.service.spec.ts
@@ -1,0 +1,55 @@
+import { InternalServerErrorException } from '@nestjs/common/exceptions';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoggerModule } from '@us-epa-camd/easey-common/logger';
+import { GasTypeCode } from '../entities/gas-type-code.entity';
+import { GasTypeCodeRepository } from './gas-type-code.repository';
+import { GasTypeCodeService } from './gas-type-code.service';
+
+const gasTypeCode = new GasTypeCode();
+const mockRepository = () => ({
+  getGasTypeCodes: jest.fn().mockResolvedValue([gasTypeCode]),
+});
+
+describe('GasTypeCodeService', () => {
+  let service: GasTypeCodeService;
+  let repository: GasTypeCodeRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [LoggerModule],
+      providers: [
+        GasTypeCodeService,
+        {
+          provide: GasTypeCodeRepository,
+          useFactory: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<GasTypeCodeService>(GasTypeCodeService);
+    repository = module.get<GasTypeCodeRepository>(GasTypeCodeRepository);
+  });
+
+  describe('getGasTypeCodes', () => {
+    it('calls the GasTypeCodeRepository and return gas type codes', async () => {
+      const result = await service.getGasTypeCodes();
+      expect(result).toEqual([gasTypeCode]);
+      expect(repository.getGasTypeCodes).toHaveBeenCalled();
+    });
+
+    it('calls the GasTypeCodeRepository and return gas type codes', async () => {
+      jest.spyOn(repository, 'getGasTypeCodes').mockRejectedValue(null);
+
+      let errored = false;
+
+      try {
+        await service.getGasTypeCodes();
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+      expect(repository.getGasTypeCodes).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/gas-type-code/gas-type-code.service.ts
+++ b/src/gas-type-code/gas-type-code.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Logger } from '@us-epa-camd/easey-common/logger';
+import { GasTypeCodeDTO } from '../dto/gas-type-code.dto';
+import { GasTypeCodeRepository } from './gas-type-code.repository';
+
+@Injectable()
+export class GasTypeCodeService {
+  constructor(
+    @InjectRepository(GasTypeCodeRepository)
+    private readonly repository: GasTypeCodeRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  async getGasTypeCodes(): Promise<GasTypeCodeDTO[]> {
+    this.logger.info('Getting gas type codes');
+    let result;
+    try {
+      result = await this.repository.getGasTypeCodes();
+    } catch (e) {
+      this.logger.error(InternalServerErrorException, e.message);
+    }
+    this.logger.info('Found gas type codes');
+
+    return result;
+  }
+}

--- a/src/maps/gas-type-code.map.spec.ts
+++ b/src/maps/gas-type-code.map.spec.ts
@@ -1,0 +1,18 @@
+import { GasTypeCode } from '../entities/gas-type-code.entity';
+import { GasTypeCodeMap } from './gas-type-code.map';
+
+const gasTypeCode = '';
+const gasTypeDescription = '';
+
+const entity = new GasTypeCode();
+entity.gasTypeCode = gasTypeCode;
+entity.gasTypeDescription = gasTypeDescription;
+
+describe('GasTypeCodeMap', () => {
+  it('maps an entity to a dto', async () => {
+    const map = new GasTypeCodeMap();
+    const result = await map.one(entity);
+    expect(result.gasTypeCode).toEqual(gasTypeCode);
+    expect(result.gasTypeCodeDescription).toEqual(gasTypeDescription);
+  });
+});

--- a/src/maps/gas-type-code.map.ts
+++ b/src/maps/gas-type-code.map.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { BaseMap } from '@us-epa-camd/easey-common/maps';
+import { GasTypeCodeDTO } from 'src/dto/gas-type-code.dto';
+import { GasTypeCode } from '../entities/gas-type-code.entity';
+
+@Injectable()
+export class GasTypeCodeMap extends BaseMap<GasTypeCode, GasTypeCodeDTO> {
+  public async one(entity: GasTypeCode): Promise<GasTypeCodeDTO> {
+    return {
+      gasTypeCode: entity.gasTypeCode,
+      gasTypeCodeDescription: entity.gasTypeDescription,
+    };
+  }
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,6 +43,7 @@ import { RelationshipsModule } from './relationships/relationships.module';
 import { TestReasonCodeModule } from './test-reason-code/test-reason-code.module';
 import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { ReportingPeriodModule } from './reporting-period/reporting-period.module';
+import { GasTypeCodeModule } from './gas-type-code/gas-type-code.module';
 
 const routes: Routes = [
   {
@@ -216,6 +217,10 @@ const routes: Routes = [
   {
     path: '/reporting-periods',
     module: ReportingPeriodModule,
+  },
+  {
+    path: '/gas-type-codes',
+    module: GasTypeCodeModule,
   },
 ];
 export default routes;

--- a/src/test-reason-code/test-reason-code.controller.spec.ts
+++ b/src/test-reason-code/test-reason-code.controller.spec.ts
@@ -28,8 +28,8 @@ describe('TestReasonCodeController', () => {
   });
 
   describe('getTestReasonCodes', () => {
-    it('should call the TestReasonCodeService and return a list of test reason codes', () => {
-      expect(controller.getTestReasonCodes()).toEqual([]);
+    it('should call the TestReasonCodeService and return a list of test reason codes', async () => {
+      expect(await controller.getTestReasonCodes()).toEqual([]);
       expect(service.getTestReasonCodes).toHaveBeenCalled();
     });
   });

--- a/src/test-reason-code/test-reason-code.service.spec.ts
+++ b/src/test-reason-code/test-reason-code.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@us-epa-camd/easey-common/logger';
 import { TestReasonCodeRepository } from './test-reason-code.repository';
 import { TestReasonCodeService } from './test-reason-code.service';
 
@@ -13,6 +14,7 @@ describe('TestReasonCodeService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        Logger,
         TestReasonCodeService,
         {
           provide: TestReasonCodeRepository,

--- a/src/test-type-code/test-type-code.controller.spec.ts
+++ b/src/test-type-code/test-type-code.controller.spec.ts
@@ -2,13 +2,20 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TestTypeCodeController } from './test-type-code.controller';
 import { TestTypeCodeService } from './test-type-code.service';
 
+const mockService = () => ({});
+
 describe('TestTypeCodeController', () => {
   let controller: TestTypeCodeController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TestTypeCodeController],
-      providers: [TestTypeCodeService],
+      providers: [
+        {
+          provide: TestTypeCodeService,
+          useFactory: mockService,
+        },
+      ],
     }).compile();
 
     controller = module.get<TestTypeCodeController>(TestTypeCodeController);

--- a/src/test-type-code/test-type-code.service.spec.ts
+++ b/src/test-type-code/test-type-code.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { TestTypeCodeRepository } from './test-type-code.repository';
 import { TestTypeCodeService } from './test-type-code.service';
+
+const mockRepository = () => ({});
 
 describe('TestTypeCodeService', () => {
   let service: TestTypeCodeService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TestTypeCodeService],
+      providers: [
+        TestTypeCodeService,
+        {
+          provide: TestTypeCodeRepository,
+          useFactory: mockRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<TestTypeCodeService>(TestTypeCodeService);

--- a/src/test-type-code/test-type-code.service.ts
+++ b/src/test-type-code/test-type-code.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { TestTypeCodeDTO } from '../dto/test-type-code.dto';
 import { TestTypeCodeRepository } from './test-type-code.repository';
 
 @Injectable()
 export class TestTypeCodeService {
-  constructor(private readonly repository: TestTypeCodeRepository) {}
+  constructor(
+    @InjectRepository(TestTypeCodeRepository)
+    private readonly repository: TestTypeCodeRepository,
+  ) {}
 
   async getTestTypeCodes(): Promise<TestTypeCodeDTO[]> {
-    return await this.repository.getTestTypeCodes();
+    return this.repository.getTestTypeCodes();
   }
 }


### PR DESCRIPTION
## [Feature/3773: Create MDM Endpoints for Gas Level Code (Linearity Summary)](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3773)