### PR TITLE
Feature/3832: GET endpoint for Test Type Group Codes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -117,7 +117,6 @@ import { GasLevelCodeModule } from './gas-level-code/gas-level-code.module';
     TestResultCodeModule,
     TestTypeGroupCodesModule,
     GasLevelCodeModule,
-
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -55,6 +55,7 @@ import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { ReportingPeriodModule } from './reporting-period/reporting-period.module';
 import { GasTypeCodeModule } from './gas-type-code/gas-type-code.module';
 import { TestResultCodeModule } from './test-result-code/test-result-code.module';
+import { TestTypeGroupCodesModule } from './test-type-group-codes/test-type-group-codes.module';
 
 @Module({
   imports: [
@@ -113,6 +114,7 @@ import { TestResultCodeModule } from './test-result-code/test-result-code.module
     ReportingPeriodModule,
     GasTypeCodeModule,
     TestResultCodeModule,
+    TestTypeGroupCodesModule,
   ],
 })
 export class AppModule {}

--- a/src/dto/test-type-group-code.dto.ts
+++ b/src/dto/test-type-group-code.dto.ts
@@ -1,0 +1,4 @@
+export class TestTypeGroupCodeDTO {
+  testTypeGroupCode: string;
+  testTypeGroupCodeDescription: string;
+}

--- a/src/entities/test-type-group-code.entity.ts
+++ b/src/entities/test-type-group-code.entity.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm';
+
+@Entity({
+  name: 'camdecmpsmd.test_type_group_code',
+})
+export class TestTypeGroupCode extends BaseEntity {
+  @PrimaryColumn({
+    type: 'varchar',
+    length: 7,
+    name: 'test_type_group_cd',
+  })
+  testTypeGroupCode: string;
+
+  @Column({
+    type: 'varchar',
+    length: 7,
+    nullable: false,
+    name: 'test_type_group_cd_description',
+  })
+  testTypeGroupCodeDescription: string;
+}

--- a/src/gas-type-code/gas-type-code.controller.spec.ts
+++ b/src/gas-type-code/gas-type-code.controller.spec.ts
@@ -28,8 +28,8 @@ describe('GasTypeCodeController', () => {
     service = module.get<GasTypeCodeService>(GasTypeCodeService);
   });
 
-  describe('getQualTypeCodes', () => {
-    it('should call the QualTypeCodeService and return a list of qual data type codes', async () => {
+  describe('getGasTypeCodes', () => {
+    it('should call the service.getGasTypeCodes and return a list of gas type codes', async () => {
       const result = await controller.getGasTypeCodes();
       expect(result).toEqual([gasTypeCodeDTO]);
       expect(service.getGasTypeCodes).toHaveBeenCalled();

--- a/src/maps/test-type-group-code.map.spec.ts
+++ b/src/maps/test-type-group-code.map.spec.ts
@@ -1,0 +1,20 @@
+import { TestTypeGroupCode } from '../entities/test-type-group-code.entity';
+import { TestTypeGroupCodeMap } from './test-type-group-code.map';
+
+const testTypeGroupCode = '';
+const testTypeGroupCodeDescription = '';
+
+const entity = new TestTypeGroupCode();
+entity.testTypeGroupCode = testTypeGroupCode;
+entity.testTypeGroupCodeDescription = testTypeGroupCodeDescription;
+
+describe('TestTypeGroupCodeMap', () => {
+  it('maps an entity to a dto', async () => {
+    const map = new TestTypeGroupCodeMap();
+    const result = await map.one(entity);
+    expect(result.testTypeGroupCode).toEqual(testTypeGroupCode);
+    expect(result.testTypeGroupCodeDescription).toEqual(
+      testTypeGroupCodeDescription,
+    );
+  });
+});

--- a/src/maps/test-type-group-code.map.ts
+++ b/src/maps/test-type-group-code.map.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { BaseMap } from '@us-epa-camd/easey-common/maps';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCode } from '../entities/test-type-group-code.entity';
+
+@Injectable()
+export class TestTypeGroupCodeMap extends BaseMap<
+  TestTypeGroupCode,
+  TestTypeGroupCodeDTO
+> {
+  public async one(entity: TestTypeGroupCode): Promise<TestTypeGroupCodeDTO> {
+    return {
+      testTypeGroupCode: entity.testTypeGroupCode,
+      testTypeGroupCodeDescription: entity.testTypeGroupCodeDescription,
+    };
+  }
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -45,6 +45,7 @@ import { TestTypeCodeModule } from './test-type-code/test-type-code.module';
 import { ReportingPeriodModule } from './reporting-period/reporting-period.module';
 import { GasTypeCodeModule } from './gas-type-code/gas-type-code.module';
 import { TestResultCodeModule } from './test-result-code/test-result-code.module';
+import { TestTypeGroupCodesModule } from './test-type-group-codes/test-type-group-codes.module';
 
 const routes: Routes = [
   {
@@ -212,6 +213,10 @@ const routes: Routes = [
   {
     path: '/test-type-codes',
     module: TestTypeCodeModule,
+  },
+  {
+    path: '/test-type-group-codes',
+    module: TestTypeGroupCodesModule,
   },
   {
     path: '/transaction-types',

--- a/src/test-type-group-codes/test-type-group-code.repository.spec.ts
+++ b/src/test-type-group-codes/test-type-group-code.repository.spec.ts
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCode } from '../entities/test-type-group-code.entity';
+import { SelectQueryBuilder } from 'typeorm';
+import { TestTypeGroupCodeRepository } from './test-type-group-code.repository';
+
+const mockQueryBuilder = () => ({
+  select: jest.fn(),
+  getMany: jest.fn(),
+});
+
+describe('TestTypeGroupCodeRepository', () => {
+  let repository;
+  let queryBuilder;
+  const testTypeGroupCodeDTO = new TestTypeGroupCodeDTO();
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        TestTypeGroupCodeRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+      ],
+    }).compile();
+
+    repository = module.get<TestTypeGroupCodeRepository>(
+      TestTypeGroupCodeRepository,
+    );
+
+    queryBuilder = module.get<SelectQueryBuilder<TestTypeGroupCode>>(
+      SelectQueryBuilder,
+    );
+
+    repository.createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
+  });
+
+  describe('getTestTypeGroupCodes', () => {
+    it('calls createQueryBuilder and gets all test type group codes from the repository', async () => {
+      queryBuilder.select.mockReturnValue(queryBuilder);
+      queryBuilder.getMany.mockReturnValue(testTypeGroupCodeDTO);
+
+      let result = await repository.getTestTypeGroupCodes();
+
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual(testTypeGroupCodeDTO);
+    });
+  });
+});

--- a/src/test-type-group-codes/test-type-group-code.repository.ts
+++ b/src/test-type-group-codes/test-type-group-code.repository.ts
@@ -1,0 +1,11 @@
+import { TestTypeGroupCode } from '../entities/test-type-group-code.entity';
+import { EntityRepository, Repository } from 'typeorm';
+
+@EntityRepository(TestTypeGroupCode)
+export class TestTypeGroupCodeRepository extends Repository<TestTypeGroupCode> {
+  async getTestTypeGroupCodes(): Promise<TestTypeGroupCode[]> {
+    return this.createQueryBuilder('ttgc')
+      .select()
+      .getMany();
+  }
+}

--- a/src/test-type-group-codes/test-type-group-codes.controller.spec.ts
+++ b/src/test-type-group-codes/test-type-group-codes.controller.spec.ts
@@ -6,7 +6,7 @@ import { TestTypeGroupCodesService } from './test-type-group-codes.service';
 const testTypeGroupCodeDTO = new TestTypeGroupCodeDTO();
 
 const mockService = () => ({
-  getGasTypeCodes: jest.fn().mockResolvedValue([testTypeGroupCodeDTO]),
+  getTestTypeGroupCodes: jest.fn().mockResolvedValue([testTypeGroupCodeDTO]),
 });
 
 describe('TestTypeGroupCodesController', () => {
@@ -30,7 +30,11 @@ describe('TestTypeGroupCodesController', () => {
     service = module.get<TestTypeGroupCodesService>(TestTypeGroupCodesService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('getTestTypeGroupCodes', () => {
+    it('should call the service.getTestTypeGroupCodes and return a list of test type group codes', async () => {
+      const result = await controller.getTestTypeGroupCodes();
+      expect(result).toEqual([testTypeGroupCodeDTO]);
+      expect(service.getTestTypeGroupCodes).toHaveBeenCalled();
+    });
   });
 });

--- a/src/test-type-group-codes/test-type-group-codes.controller.spec.ts
+++ b/src/test-type-group-codes/test-type-group-codes.controller.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCodesController } from './test-type-group-codes.controller';
+import { TestTypeGroupCodesService } from './test-type-group-codes.service';
+
+const testTypeGroupCodeDTO = new TestTypeGroupCodeDTO();
+
+const mockService = () => ({
+  getGasTypeCodes: jest.fn().mockResolvedValue([testTypeGroupCodeDTO]),
+});
+
+describe('TestTypeGroupCodesController', () => {
+  let controller: TestTypeGroupCodesController;
+  let service: TestTypeGroupCodesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestTypeGroupCodesController],
+      providers: [
+        {
+          provide: TestTypeGroupCodesService,
+          useFactory: mockService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<TestTypeGroupCodesController>(
+      TestTypeGroupCodesController,
+    );
+    service = module.get<TestTypeGroupCodesService>(TestTypeGroupCodesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/test-type-group-codes/test-type-group-codes.controller.ts
+++ b/src/test-type-group-codes/test-type-group-codes.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiOkResponse,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCodesService } from './test-type-group-codes.service';
+
+@Controller()
+@ApiSecurity('APIKey')
+@ApiTags('Test Type Group Codes')
+export class TestTypeGroupCodesController {
+  constructor(private readonly service: TestTypeGroupCodesService) {}
+
+  @Get()
+  @ApiOkResponse({
+    isArray: true,
+    type: TestTypeGroupCodeDTO,
+    description: 'Retrieves all valid Test Type Group Codes',
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid Request',
+  })
+  async getTestTypeCodes(): Promise<TestTypeGroupCodeDTO[]> {
+    return this.service.getTestTypeGroupCodes();
+  }
+}

--- a/src/test-type-group-codes/test-type-group-codes.controller.ts
+++ b/src/test-type-group-codes/test-type-group-codes.controller.ts
@@ -23,7 +23,7 @@ export class TestTypeGroupCodesController {
   @ApiBadRequestResponse({
     description: 'Invalid Request',
   })
-  async getTestTypeCodes(): Promise<TestTypeGroupCodeDTO[]> {
+  async getTestTypeGroupCodes(): Promise<TestTypeGroupCodeDTO[]> {
     return this.service.getTestTypeGroupCodes();
   }
 }

--- a/src/test-type-group-codes/test-type-group-codes.module.ts
+++ b/src/test-type-group-codes/test-type-group-codes.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TestTypeGroupCodesService } from './test-type-group-codes.service';
+import { TestTypeGroupCodesController } from './test-type-group-codes.controller';
+import { TestTypeGroupCodeRepository } from './test-type-group-code.repository';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TestTypeGroupCodeMap } from '../maps/test-type-group-code.map';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TestTypeGroupCodeRepository])],
+  controllers: [TestTypeGroupCodesController],
+  providers: [TestTypeGroupCodesService, TestTypeGroupCodeMap],
+  exports: [TypeOrmModule, TestTypeGroupCodesService, TestTypeGroupCodeMap],
+})
+export class TestTypeGroupCodesModule {}

--- a/src/test-type-group-codes/test-type-group-codes.service.spec.ts
+++ b/src/test-type-group-codes/test-type-group-codes.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestTypeGroupCodesService } from './test-type-group-codes.service';
+
+describe('TestTypeGroupCodesService', () => {
+  let service: TestTypeGroupCodesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TestTypeGroupCodesService],
+    }).compile();
+
+    service = module.get<TestTypeGroupCodesService>(TestTypeGroupCodesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/test-type-group-codes/test-type-group-codes.service.spec.ts
+++ b/src/test-type-group-codes/test-type-group-codes.service.spec.ts
@@ -1,18 +1,54 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCodeRepository } from './test-type-group-code.repository';
 import { TestTypeGroupCodesService } from './test-type-group-codes.service';
+
+const testTypeGroupCodeDTO = new TestTypeGroupCodeDTO();
+const mockRepository = () => ({
+  getTestTypeGroupCodes: jest.fn().mockResolvedValue([testTypeGroupCodeDTO]),
+});
 
 describe('TestTypeGroupCodesService', () => {
   let service: TestTypeGroupCodesService;
+  let repository: TestTypeGroupCodeRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TestTypeGroupCodesService],
+      providers: [
+        TestTypeGroupCodesService,
+        {
+          provide: TestTypeGroupCodeRepository,
+          useFactory: mockRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<TestTypeGroupCodesService>(TestTypeGroupCodesService);
+    repository = module.get<TestTypeGroupCodeRepository>(
+      TestTypeGroupCodeRepository,
+    );
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('getTestTypeGroupCodes', () => {
+    it('calls the TestTypeGroupCodeRepository and return test type group codes', async () => {
+      const result = await service.getTestTypeGroupCodes();
+      expect(result).toEqual([testTypeGroupCodeDTO]);
+      expect(repository.getTestTypeGroupCodes).toHaveBeenCalled();
+    });
+
+    it('calls the TestTypeGroupCodeRepository and return test type group codes', async () => {
+      jest.spyOn(repository, 'getTestTypeGroupCodes').mockRejectedValue(null);
+
+      let errored = false;
+
+      try {
+        await service.getTestTypeGroupCodes();
+      } catch (e) {
+        errored = true;
+      }
+
+      expect(errored).toEqual(true);
+      expect(repository.getTestTypeGroupCodes).toHaveBeenCalled();
+    });
   });
 });

--- a/src/test-type-group-codes/test-type-group-codes.service.ts
+++ b/src/test-type-group-codes/test-type-group-codes.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { TestTypeGroupCodeDTO } from '../dto/test-type-group-code.dto';
+import { TestTypeGroupCodeRepository } from './test-type-group-code.repository';
+
+@Injectable()
+export class TestTypeGroupCodesService {
+  constructor(
+    @InjectRepository(TestTypeGroupCodeRepository)
+    private readonly repository: TestTypeGroupCodeRepository,
+  ) {}
+
+  async getTestTypeGroupCodes(): Promise<TestTypeGroupCodeDTO[]> {
+    return this.repository.getTestTypeGroupCodes();
+  }
+}


### PR DESCRIPTION
## [Feature/3832: GET endpoint for Test Type Group Codes](https://app.zenhub.com/workspaces/emissioners-scrum-board-5f36cd263511ad001a777f8e/issues/us-epa-camd/easey-ui/3832)
