### PR TITLE
Update package.json to use tilde for easey-common versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "17.3.1",
+    "@us-epa-camd/easey-common": "~17.8.2",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/platform-express": "^8.4.7",
     "@nestjs/swagger": "5.1.2",
     "@nestjs/typeorm": "^8.0.3",
-    "@us-epa-camd/easey-common": "~17.8.2",
+    "@us-epa-camd/easey-common": "~17.3.1",
     "class-transformer": "0.4.0",
     "class-validator": "0.14.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
change the versioning for easey-common dependency to use tilde to avoid picking up anything but minor updates