### PR TITLE
added EASEY_MDM_API_KEY in config

### DIFF
--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -61,4 +61,5 @@ export default registerAs('app', () => ({
   authApi: {
     uri: getConfigValue('EASEY_AUTH_API', `https://${apiHost}/auth-mgmt`),
   },
+  apiKey: getConfigValue('EASEY_MDM_API_KEY'),
 }));


### PR DESCRIPTION
Currently, the mdm-api does not have an API_KEY in the config, and since checking the maintenance status of the Auth-api requires an apiKey, the mdm-api is failing due to the missing API_KEY.
For testing purposes, 
API_KEY added in the config