### PR TITLE
Fix/#6767 Sort reporting filter most recent -- [#6767]

### DIFF
--- a/src/reporting-period/reporting-period.service.ts
+++ b/src/reporting-period/reporting-period.service.ts
@@ -18,14 +18,28 @@ export class ReportingPeriodService {
       const today = new Date(Date.now());
       const currentYear = today.getFullYear();
       const currentQuarter = Math.floor(today.getMonth() / 3 + 1);
-      const periodAbbreviation = `${currentYear} Q${currentQuarter}`;
+      const whereConditions: any = isExport
+        ? [
+            { calendarYear: LessThan(currentYear) },
+            {
+              calendarYear: currentYear,
+              quarter: LessThan(currentQuarter)
+            }
+          ]
+        : [
+            { calendarYear: LessThan(currentYear) },
+            {
+              calendarYear: currentYear,
+              quarter: LessThanOrEqual(currentQuarter)
+            }
+          ];
 
       const results = await this.repository.find({
-        where: {
-          periodAbbreviation: isExport
-            ? LessThan(periodAbbreviation)
-            : LessThanOrEqual(periodAbbreviation),
-        },
+        where: whereConditions,
+        order: {
+          calendarYear: 'DESC',
+          quarter: 'DESC'
+        }
       });
       return this.map.many(results);
     } catch (e) {


### PR DESCRIPTION
 ## Summary
  - Fix reporting periods defaulting to 2020 Q4 instead of current period
  (2025 Q3)
  - Replace string-based date filtering with proper chronological
  comparison in MDM API
  - Add explicit database ordering to ensure consistent sorting

  ## Root Cause
  The `getReportingPeriods` service was using `LessThan("2025 Q3")` string
  comparison on `periodAbbreviation`, causing lexicographical ordering
  where "2020 Q4" > "2025 Q3" because "2" > "1".

  ## Changes
  - **File**: `src/reporting-period/reporting-period.service.ts`
  - Replace `periodAbbreviation` string filtering with numeric
  `calendarYear` and `quarter` field comparison
  - Add explicit `ORDER BY calendarYear DESC, quarter DESC` to database
  query
  - Maintain backward compatibility for both normal and export modes

  ## Test Plan
  - [ ] Verify API returns 2025 Q3 as first item in normal mode
  - [ ] Verify API returns 2025 Q2 as first item in export mode
  - [ ] Test ECMPS UI dropdowns show correct default selection
  - [ ] Run existing unit and integration tests
