### PR TITLE
Feature/7027 read replica flag

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -22,6 +22,7 @@ applications:
       EASEY_MDM_API_ENABLE_SECRET_TOKEN: true
       EASEY_MDM_API_ENABLE_CORS: true
       EASEY_MDM_API_ENABLE_GLOBAL_VALIDATION_PIPE: true
+      EASEY_MDM_API_ENABLE_REPLICA_DB_ACCESS: true
       EASEY_API_GATEWAY_HOST: ((apiHost))
       TZ: America/New_York
       EASEY_AUTH_API: https://((apiHost))/auth-mgmt

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -47,6 +47,9 @@ export default registerAs('app', () => ({
   enableGlobalValidationPipes: getConfigValueBoolean(
     'EASEY_MDM_API_ENABLE_GLOBAL_VALIDATION_PIPE', true,
   ),
+  enableReplicaDbAccess: getConfigValueBoolean(
+    'EASEY_MDM_API_ENABLE_REPLICA_DB_ACCESS',
+  ),
   version: getConfigValue(
     'EASEY_MDM_API_VERSION', 'v0.0.0',
   ),

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -35,6 +35,8 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
     const host = this.configService.get<string>('database.host');
     const replicaHost = this.configService.get<string>('database.replicaHost');
 
+    const replicaAccessEnabled = this.configService.get<boolean>('app.enableReplicaDbAccess');
+
     // Common configuration shared between replication and single connection modes
     const commonConfig = {
       type: 'postgres' as const,
@@ -53,7 +55,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
     };
 
     // Use replication only when replica host is different from primary host
-    if (replicaHost && replicaHost !== host) {
+    if (replicaAccessEnabled && replicaHost && replicaHost !== host) {
     return {
       ...commonConfig,
       replication: {


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/7027

## Main Changes:

- Added an environment variable to toggle access to the read-only replica database.