### PR TITLE
configure rootDir/outDir explicitly to keep dist/main.js at root

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "target": "es2017",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true


### PR DESCRIPTION
configure rootDir/outDir explicitly to keep dist/main.js at root